### PR TITLE
add @googlemaps/jest-mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-google-layer",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -233,6 +233,12 @@
         }
       }
     },
+    "@googlemaps/jest-mocks": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/jest-mocks/-/jest-mocks-0.1.1.tgz",
+      "integrity": "sha512-n+lANUnxETOyt/nSQV8LsmqAZJbGiC3r+aXEPn95U//k+5dVszQlfeZxSYAI0Gc3YfunyD9VyLbyMpm+S663Mg==",
+      "dev": true
+    },
     "@googlemaps/js-api-loader": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.8.0.tgz",
@@ -461,6 +467,12 @@
       "version": "7946.0.7",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
       "integrity": "sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ=="
+    },
+    "@types/googlemaps": {
+      "version": "3.43.3",
+      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
+      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "1.1.0",
@@ -1856,21 +1868,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
       "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
       "dev": true
-    },
-    "google-maps": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/google-maps/-/google-maps-4.3.3.tgz",
-      "integrity": "sha512-MQbEgBNQbGyV7mfS2tlFgW4EoGKLia24BvAl4a+kgsYWt4283kyPpaay/yKIsScQLr7nSUONaLNfOdMsCuJDEw==",
-      "requires": {
-        "@types/googlemaps": "^3.39.1"
-      },
-      "dependencies": {
-        "@types/googlemaps": {
-          "version": "3.40.3",
-          "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.40.3.tgz",
-          "integrity": "sha512-ivlG5S0LlnQgpgPnQCUNAs7kjBtO367ZwDmuK+ggsQfW+w4N0RyWbxWZ6vPwegDe50Du3Xbb5+QVwJuB/U1XpA=="
-        }
-      }
     },
     "graceful-fs": {
       "version": "4.1.15",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "react-leaflet": "^3.0.0"
   },
   "devDependencies": {
+    "@googlemaps/jest-mocks": "^0.1.1",
+    "@types/googlemaps": "^3.43.3",
     "@types/jest": "^24.0.9",
     "@types/react": "^16.8.7",
     "@types/react-dom": "^16.8.2",

--- a/src/__tests__/ReactLeafletGoogleLayer.test.tsx
+++ b/src/__tests__/ReactLeafletGoogleLayer.test.tsx
@@ -3,18 +3,22 @@ import ReactDOM from 'react-dom';
 import ReactLeafletGoogleLayer from '../index';
 import { MapContainer } from 'react-leaflet';
 import * as ReactTestUtils from 'react-dom/test-utils';
+import { initialize } from '@googlemaps/jest-mocks';
 
-
-test('ReactLeafletGoogleLayer', () => {
-  expect(ReactLeafletGoogleLayer);   
-
-  const dom = ReactTestUtils.renderIntoDocument(
-    <div>
-      <MapContainer>
-        <ReactLeafletGoogleLayer />
-      </MapContainer>
-    </div>
-  ) as any;
-  const component = ReactDOM.findDOMNode(dom.childNodes[0]) as any;
-  expect(component).toBeInstanceOf(HTMLElement);
+describe('ReactLeafletGoogleLayer', () => {
+  beforeEach(() => {
+    initialize();
+  })
+  it('Draw HTML element', () => {
+    expect(ReactLeafletGoogleLayer);   
+    const dom = ReactTestUtils.renderIntoDocument(
+      <div>
+        <MapContainer>
+          <ReactLeafletGoogleLayer />
+        </MapContainer>
+      </div>
+    ) as any;
+    const component = ReactDOM.findDOMNode(dom.childNodes[0]) as any;
+    expect(component).toBeInstanceOf(HTMLElement);
+  })
 });


### PR DESCRIPTION
## About

This PR add two devDependencies, `@googlemaps/jest-mocks` and `@types/googlemaps` and update test.

## Why

I encountered some error that says "'google' is undefined" when running jest in Docker.
I solved that problem by looking for mock of google maps for jest.

`@googlemaps/jest-mocks` needs `@types/googlemaps` to solve the type of Typescript

## How to Check this Pull Request

1. Checkout this branch
2. 
```
npm i
npm test
```

## References
- https://github.com/googlemaps/v3-utility-library
- https://github.com/googlemaps/v3-utility-library/tree/master/packages/jest-mocks
- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/googlemaps