### PR TITLE
Add optional mapId prop for custom cloud map styles

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ interface IProps extends L.gridLayer.GoogleMutantOptions {
   googleMapsLoaderConf?: LoaderOptions;
   googleMapsAddLayers?: IGoogleMapsAddLayer[];
   apiKey?: string;
+  mapId?: string;
 }
 
 let googleMapsScriptLoaded = false;


### PR DESCRIPTION
As is, a Google cloud map id (for a map style defined in the Google management console) can't be passed through.

By simply adding mapId to the props definition, the existing logic passes it through to Leaflet.GridLayer.GoogleMutant: https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant/-/blob/master/src/Leaflet.GoogleMutant.js#L177

Somewhat related but not necessarily blocking - I did find a warning appearing if mapId is used due to the styles option always being set to at least an empty array. I've created a PR to fix the warning at https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant/-/merge_requests/77 but it hasn't been merged yet. The last commit was 10 months ago so it may take a while longer to get merged.